### PR TITLE
Telegram notification: Don't try call api without credentials

### DIFF
--- a/spotreba.gs
+++ b/spotreba.gs
@@ -139,6 +139,11 @@ function notifyUser(_msg, _type) {
     var userID = sh.getRange('C3').getValue();
     var token  = sh.getRange('C4').getValue();
 
+    if(userID === "" || token === "") {
+        // Telegram credentials not defined - do not use it for report
+        return;
+    }
+
     var url = ''
         +'https://api.telegram.org/bot' +token
         +'/sendMessage?chat_id=' +userID


### PR DESCRIPTION
Allow to disable Telegram logging