### PR TITLE
Set minimal required PHP 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
+        "php":"^7.3",
         "ext-curl":"*",
         "ext-json":"*",
         "ext-mbstring":"*",


### PR DESCRIPTION
Nastavuju minimální verzi PHP na 7.3, to aby se neinstalovaly balíčky podporující třeba nějakou jinou verzi.