### PR TITLE
Never use `include`

### DIFF
--- a/add.php
+++ b/add.php
@@ -1,1 +1,1 @@
-<?php include("index.php");
+<?php require __DIR__ . '/index.php';

--- a/create.php
+++ b/create.php
@@ -1,1 +1,1 @@
-<?php include("index.php");
+<?php require __DIR__ . '/index.php';

--- a/index.php
+++ b/index.php
@@ -91,24 +91,24 @@ if(Helpers::isFormSent('form-create')){ // odesláno
 
 ?>
 
-<? include("page/head.php"); ?>
+<? require __DIR__ . '/page/head.php'; ?>
 
 <body>
 
-<?php include("page/datalists.php"); ?>
+<?php require __DIR__ . '/page/datalists.php'; ?>
 
-<?php include("page/navbar.php"); ?>
-<?php include("page/statusbar.php"); ?>
+<?php require __DIR__ . '/page/navbar.php'; ?>
+<?php require __DIR__ . '/page/statusbar.php'; ?>
 
 <?php
 
     switch($page) {
-        case 'add': include("forms/add.php"); break;
-        case 'tank': include("forms/tank.php"); break;
-        case 'create': include("forms/create.php"); break;
-        case 'show': include("page/show.php"); break;
-        case 'welcome': include("page/welcome.php"); break;
-        default: include("page/404.php"); break;
+        case 'add': require __DIR__ . '/forms/add.php'; break;
+        case 'tank': require __DIR__ . '/forms/tank.php'; break;
+        case 'create': require __DIR__ . '/forms/create.php'; break;
+        case 'show': require __DIR__ . '/page/show.php'; break;
+        case 'welcome': require __DIR__ . '/page/welcome.php'; break;
+        default: require __DIR__ . '/page/404.php'; break;
     }
 
 ?>

--- a/tank.php
+++ b/tank.php
@@ -1,1 +1,1 @@
-<?php include("index.php");
+<?php require __DIR__ . '/index.php';


### PR DESCRIPTION
Pamatuj si, že vždy při načítání PHP souboru je potřeba použít `require()` a **naopak nikdy nepoužívat `include()`**.

Jde o to, že kdyby se tam objevila chyba, tak `include()` někde hluboko vyhodí tichý warning a pokračuje jakoby nic, to `require()` neudělá - tam chybu nepřehlédneš.

Dále **nikdy nepoužívej  relativní cesty**, protože u malé aplikace je to sice víceméně funkční, ale u velké aplikace to začne být problém, protože PHP v tomhle požívá logiku adresářových cest naprosto dementně. Tedy navykni si vždy používat absolutní cesty pomocí `__DIR__`, který vždy ukazuje na adresář aktuálního souboru (toho, v němž je `__DIR__` napsán, nikoliv toho, který je volaný v URL).